### PR TITLE
Make it possible to have an arbitrary number of simultaneous mounts.

### DIFF
--- a/anylinuxfs/src/main.rs
+++ b/anylinuxfs/src/main.rs
@@ -2323,8 +2323,6 @@ impl AppRunner {
         let _lock_file = LockFile::new(LOCK_FILE)?.acquire_lock(FlockKind::Shared)?;
         let mut network_env = NetworkEnv::default();
 
-        network_env.usable_loopback_ip = netutil::pick_usable_loopback_ip(&[2049, 32765, 32767])?;
-
         if let Err(e) = netutil::try_port((Ipv4Addr::from([0, 0, 0, 0]), 111))
             && e.kind() == io::ErrorKind::AddrInUse
         {
@@ -2388,7 +2386,7 @@ impl AppRunner {
     fn run_mount_child(
         &mut self,
         mut config: MountConfig,
-        network_env: NetworkEnv,
+        mut network_env: NetworkEnv,
         comm_write_fd: libc::c_int,
     ) -> anyhow::Result<()> {
         // pre-declare so it can be referenced in a deferred action
@@ -2541,11 +2539,8 @@ impl AppRunner {
         let (mut net_helper_proc, net_helper_name, vmnet_config, vm_ip) =
             match config.common.net_helper {
                 NetHelper::GvProxy => {
-                    let Some(loopback_ip) = network_env.usable_loopback_ip.clone() else {
-                        return Err(anyhow!(
-                            "You can only mount up to three drives with gvproxy"
-                        ));
-                    };
+                    let loopback_ip = netutil::pick_usable_loopback_ip(&[2049, 32765, 32767])?;
+                    network_env.usable_loopback_ip = Some(loopback_ip.clone());
                     (
                         vm_network::start_gvproxy(&config.common)?,
                         "gvproxy",

--- a/anylinuxfs/src/netutil.rs
+++ b/anylinuxfs/src/netutil.rs
@@ -4,6 +4,7 @@ use std::{
     fmt::Display,
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs},
+    process::Command,
     ptr::null_mut,
 };
 
@@ -12,6 +13,7 @@ use getifaddrs::{InterfaceFilter, InterfaceFlags};
 use ipnet::Ipv4Net;
 use objc2_core_foundation::{CFArray, CFDictionary, CFString};
 use objc2_system_configuration::SCDynamicStore;
+use std::net::Ipv6Addr;
 
 use crate::utils::cfdict_get_value;
 
@@ -202,14 +204,44 @@ impl Display for Host {
     }
 }
 
-pub fn pick_usable_loopback_ip(required_ports: &[u16]) -> anyhow::Result<Option<Host>> {
-    for addr in ["127.0.0.1", "::1", "fe80::1%lo0"] {
+fn make_new_loopback() -> anyhow::Result<Host> {
+    let addr = Ipv6Addr::new(
+        0xFE80,
+        0,
+        0,
+        0,
+        rand::random(),
+        rand::random(),
+        rand::random(),
+        rand::random(),
+    );
+    let success = Command::new("/sbin/ifconfig")
+        .arg("lo0")
+        .arg("inet6")
+        .arg(addr.to_string())
+        .arg("add")
+        .status()?
+        .success();
+    if success {
+        Ok(Host::from_ip(IpAddr::V6(addr), Some(1)))
+    } else {
+        Err(anyhow!("unable to create an additional loopback address"))
+    }
+}
+
+pub fn pick_usable_loopback_ip(required_ports: &[u16]) -> anyhow::Result<Host> {
+    for itf in InterfaceFilter::new().name("lo0").get()? {
+        let Some(addr) = itf.address.ip_addr() else {
+            continue;
+        };
         let mut ip_candidate = None;
-        let mut ipv6_scope = None;
+        let ipv6_scope = if addr.is_ipv6() { itf.index } else { None };
         for port in required_ports.iter().cloned() {
-            if let Some(sock) = (addr, port).to_socket_addrs()?.next() {
-                if let SocketAddr::V6(sock) = sock {
-                    ipv6_scope = Some(sock.scope_id());
+            if let Some(mut sock) = (addr, port).to_socket_addrs()?.next() {
+                if let SocketAddr::V6(sock6) = &mut sock
+                    && let Some(scope) = ipv6_scope
+                {
+                    sock6.set_scope_id(scope);
                 }
                 match try_port(sock) {
                     Ok(()) => {
@@ -229,14 +261,13 @@ pub fn pick_usable_loopback_ip(required_ports: &[u16]) -> anyhow::Result<Option<
         }
         if let Some(ip) = ip_candidate {
             if let Some(scope_id) = ipv6_scope {
-                return Ok(Some(Host::from_ip(ip, Some(scope_id))));
+                return Ok(Host::from_ip(ip, Some(scope_id)));
             } else {
-                return Ok(Some(Host::from_ip(ip, None)));
+                return Ok(Host::from_ip(ip, None));
             }
         }
     }
-
-    Ok(None)
+    make_new_loopback()
 }
 
 #[allow(unused)]


### PR DESCRIPTION
Gvproxy was limited to only 3 mounts due to running out of loopback addresses. So, let's just add more if we run out, ipv6 lets us have 2^64 link-local addresses, that should be enough for everyone.